### PR TITLE
Add tests to use-sinon branch

### DIFF
--- a/src/providers/super.provider.spec.ts
+++ b/src/providers/super.provider.spec.ts
@@ -16,32 +16,836 @@
 
 import 'reflect-metadata';
 import * as assert from 'assert';
+import * as sinon from 'ts-sinon';
+import { SinonSandbox } from 'sinon';
 import { ManualSignProvider } from './super.provider';
+import { ISuperblocksClient, IPusherClient, IRpcClient, IEventResponse } from '../ioc/interfaces';
+import { ITransactionModel } from '../superblocks/models';
+import { JSONRPCRequestPayload, JSONRPCResponsePayload } from 'ethereum-protocol';
+
+
+// Disable specific tslint warnings
+/* tslint:disable:no-unused-expression */
+/* tslint:disable:max-classes-per-file */
 
 describe('ManualSignProvider:', () => {
-    it.skip('sends message using JSON-RPC', () => {
-        // TODO
+
+    let sandbox: SinonSandbox;
+
+    beforeEach(() => {
+        // Remove console logs to make the test results cleaner
+        sandbox = sinon.default.createSandbox();
+        sandbox.stub(console, 'log');
     });
 
-    it('fails to send message using JSON-RPC due to invalid JSON response', async () => {
-        // const superblocksProvider = new ManualSignProvider({
-        //     from: '0x0101010100101010100101010100101010101010',
-        //     endpoint: 'https://superblocks.com/',
-        //     networkId: '0'
-        // });
+    afterEach(() => {
+        sandbox.restore();
+    });
 
-        // await assert.rejects( async () => {
-        //     const promise = superblocksProvider.sendMessage({
-        //         jsonrpc: 'eth_test',
-        //         id: 0,
-        //         method: 'eth_test',
-        //         params: ['test'],
-        //     }, '0');
-        //     return promise;
-        // }, {
-        //     message: 'invalid json response body at https://superblocks.com/ reason: Unexpected token < in JSON at position 0',
-        //     type: 'invalid-json'
-        // });
+    describe('isValidEndpoint:', () => {
+        it('checks http is a valid endpoint protocol', () => {
+            const endpoint = 'http://localhost';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, true);
+        });
+
+        it('checks https is a valid endpoint protocol', () => {
+            const endpoint = 'https://localhost';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, true);
+        });
+
+        it('checks ws is a valid endpoint protocol', () => {
+            const endpoint = 'ws://localhost';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, true);
+        });
+
+        it('checks wss is a valid endpoint protocol', () => {
+            const endpoint = 'wss://localhost';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, true);
+        });
+
+        it('checks that out of place protocol is not valid', () => {
+            const endpoint = 'localhosthttp:';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, false);
+        });
+
+        it('checks that out of place protocol with slashes are invalid', () => {
+            const endpoint = 'localhosthttp://';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, false);
+        });
+
+        it('checks slashes alone do not form a valid endpoint', () => {
+            const endpoint = '//localhost';
+            const isValidEndpoint = ManualSignProvider.isValidEndpoint(endpoint);
+            assert.deepStrictEqual(isValidEndpoint, false);
+        });
+    });
+
+    describe('init:', () => {
+        it('initializes manual sign provider successfully', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: '0x3117958590752b0871548Dd8715b4C4c41372d3d',
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+        });
+
+        it('fails to initialize when from option is empty', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: '',
+                    endpoint: 'http://localhost',
+                    networkId: '1'
+                });
+            });
+        });
+
+        it('fails to initialize when from option is invalid', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: '0x1234567890',
+                    endpoint: 'http://localhost',
+                    networkId: '1'
+                });
+            });
+        });
+
+        it('fails to initialize when endpoint option is empty', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: '0x3117958590752b0871548Dd8715b4C4c41372d3d',
+                    endpoint: '',
+                    networkId: '1'
+                });
+            });
+        });
+
+        it('fails to initialize when endpoint option is missing protocol', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: '0x3117958590752b0871548Dd8715b4C4c41372d3d',
+                    endpoint: 'localhost',
+                    networkId: '1'
+                });
+            });
+        });
+
+        it('fails to initialize when network id option is empty', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: '0x3117958590752b0871548Dd8715b4C4c41372d3d',
+                    endpoint: 'http://localhost',
+                    networkId: ''
+                });
+            });
+        });
+
+        it('fails to initialize when network id option is not a number', () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: '0x3117958590752b0871548Dd8715b4C4c41372d3d',
+                    endpoint: 'http://localhost',
+                    networkId: 'one'
+                });
+            });
+        });
+    });
+
+    describe('getAccounts:', () => {
+        it('retrieves accounts successfully', async () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            const accounts = await manualSignProvider.getAccounts();
+            assert.deepStrictEqual([ fromAddress ], accounts);
+        });
+
+        it('fails to retrieve accounts due to initialized provider', async () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            try {
+                const accounts = await manualSignProvider.getAccounts();
+            } catch (e) {
+                assert.deepStrictEqual('TypeError: Cannot read property \'from\' of undefined', e.toString());
+            }
+        });
+    });
+
+    describe('sendMessage:', () => {
+        it('successfully retrieve accounts', async () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_accounts',
+                    params: [],
+                }, '0');
+                return promise;
+            });
+        });
+
+        it('fails to retrieve accounts due to bad from address during initialization', async () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            const fromAddress = '0x1234567890';
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.rejects( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_accounts',
+                    params: [],
+                }, '0');
+                return promise;
+            });
+        });
+
+        it('fails to retrieve accounts due to empty address during initialization', async () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            const fromAddress = '';
+            assert.throws(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.rejects( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_accounts',
+                    params: [],
+                }, '0');
+                return promise;
+            });
+        });
+
+        it('successfully sends message via Rest API', async () => {
+            class TestSuperblocksClient implements ISuperblocksClient {
+                sendEthTransaction(transaction: ITransactionModel): Promise<ITransactionModel> {
+                    return new Promise(async (resolve, _) => {
+                        return resolve({
+                            projectId: transaction.projectId,
+                            buildConfigId: transaction.buildConfigId,
+                            from: transaction.from,
+                            networkId: transaction.networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: transaction.rpcPayload.method,
+                                id: transaction.rpcPayload.id,
+                                jsonrpc: transaction.rpcPayload.jsonrpc,
+                            }
+                        });
+                    });
+                }
+
+                createRelease(workspaceId: string, userToken: string, networkId: string): Promise<ITransactionModel> {
+                    return new Promise(async (_, __) => {
+                        (workspaceId);
+                        (userToken);
+                        return {
+                            projectId: 'id',
+                            buildConfigId: 'id',
+                            from: '0x0',
+                            networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: 'eth_zilch',
+                                id: '0',
+                                jsonrpc: '0',
+                            }
+                        };
+
+                    });
+                }
+            }
+
+            class TestPusherClient implements IPusherClient {
+                subscribeToChannel(channelName: string, eventNames: [string], callback: (eventResponse: IEventResponse) => any): void {
+                    (channelName);
+                    (eventNames);
+                    callback({
+                        eventName: 'update_transaction',
+                        message: channelName
+                    });
+                }
+
+                unsubscribeFromChannel(channelName: string): void {
+                    (channelName);
+                }
+            }
+
+            const superblocksClient = new TestSuperblocksClient();
+            const pusherClient = new TestPusherClient();
+            const manualSignProvider = new ManualSignProvider(superblocksClient, pusherClient, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_sendTransaction',
+                    params: [],
+                }, '0');
+                return promise;
+            });
+        });
+
+        it('fails to send message via Rest API due to Superblocks Client failure', async () => {
+            class TestSuperblocksClient implements ISuperblocksClient {
+                sendEthTransaction(transaction: ITransactionModel): Promise<ITransactionModel> {
+                    throw new Error('sendEthTransaction exception');
+                    return new Promise(async (resolve, _) => {
+                        return resolve({
+                            projectId: transaction.projectId,
+                            buildConfigId: transaction.buildConfigId,
+                            from: transaction.from,
+                            networkId: transaction.networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: transaction.rpcPayload.method,
+                                id: transaction.rpcPayload.id,
+                                jsonrpc: transaction.rpcPayload.jsonrpc,
+                            }
+                        });
+                    });
+                }
+
+                createRelease(workspaceId: string, userToken: string, networkId: string): Promise<ITransactionModel> {
+                    return new Promise(async (_, __) => {
+                        (workspaceId);
+                        (userToken);
+                        return {
+                            projectId: 'id',
+                            buildConfigId: 'id',
+                            from: '0x0',
+                            networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: 'eth_zilch',
+                                id: '0',
+                                jsonrpc: '0',
+                            }
+                        };
+
+                    });
+                }
+            }
+
+            const superblocksClient = new TestSuperblocksClient();
+            const manualSignProvider = new ManualSignProvider(superblocksClient, null, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.rejects( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_sendTransaction',
+                    params: [],
+                }, '0');
+                return promise;
+            });
+        });
+
+        it('successfully signs message via Rest API', async () => {
+            class TestSuperblocksClient implements ISuperblocksClient {
+                sendEthTransaction(transaction: ITransactionModel): Promise<ITransactionModel> {
+                    return new Promise(async (resolve, _) => {
+                        return resolve({
+                            projectId: transaction.projectId,
+                            buildConfigId: transaction.buildConfigId,
+                            from: transaction.from,
+                            networkId: transaction.networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: transaction.rpcPayload.method,
+                                id: transaction.rpcPayload.id,
+                                jsonrpc: transaction.rpcPayload.jsonrpc,
+                            }
+                        });
+                    });
+                }
+
+                createRelease(workspaceId: string, userToken: string, networkId: string): Promise<ITransactionModel> {
+                    return new Promise(async (_, __) => {
+                        (workspaceId);
+                        (userToken);
+                        return {
+                            projectId: 'id',
+                            buildConfigId: 'id',
+                            from: '0x0',
+                            networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: 'eth_zilch',
+                                id: '0',
+                                jsonrpc: '0',
+                            }
+                        };
+
+                    });
+                }
+            }
+
+            class TestPusherClient implements IPusherClient {
+                subscribeToChannel(channelName: string, eventNames: [string], callback: (eventResponse: IEventResponse) => any): void {
+                    (channelName);
+                    (eventNames);
+                    callback({
+                        eventName: 'update_transaction',
+                        message: channelName
+                    });
+                }
+
+                unsubscribeFromChannel(channelName: string): void {
+                    (channelName);
+                }
+            }
+
+            const superblocksClient = new TestSuperblocksClient();
+            const pusherClient = new TestPusherClient();
+            const manualSignProvider = new ManualSignProvider(superblocksClient, pusherClient, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_sign',
+                    params: [],
+                }, '0');
+                return promise;
+            });
+        });
+
+        it('successfully sends message via RPC', async () => {
+            class TestRpcClient implements IRpcClient {
+                sendRpcJsonCall(endpoint: string, payload: JSONRPCRequestPayload): Promise<any> {
+                    return new Promise(async (resolve, _) => {
+                        (endpoint);
+                        (payload);
+                        return resolve([]);
+                    });
+                }
+            }
+
+            const rpcClient = new TestRpcClient();
+            const manualSignProvider = new ManualSignProvider(null, null, rpcClient);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.sendMessage({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_test',
+                    params: ['test'],
+                }, '0');
+                return promise;
+            });
+        });
+    });
+
+    describe('send:', () => {
+        it('successfully retrieve accounts', async () => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.send({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_accounts',
+                    params: [],
+                });
+                return promise;
+            });
+        });
+
+        it('successfully sends message via Rest API', async () => {
+            class TestSuperblocksClient implements ISuperblocksClient {
+                sendEthTransaction(transaction: ITransactionModel): Promise<ITransactionModel> {
+                    return new Promise(async (resolve, _) => {
+                        return resolve({
+                            projectId: transaction.projectId,
+                            buildConfigId: transaction.buildConfigId,
+                            from: transaction.from,
+                            networkId: transaction.networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: transaction.rpcPayload.method,
+                                id: transaction.rpcPayload.id,
+                                jsonrpc: transaction.rpcPayload.jsonrpc,
+                            }
+                        });
+                    });
+                }
+
+                createRelease(workspaceId: string, userToken: string, networkId: string): Promise<ITransactionModel> {
+                    return new Promise(async (_, __) => {
+                        (workspaceId);
+                        (userToken);
+                        return {
+                            projectId: 'id',
+                            buildConfigId: 'id',
+                            from: '0x0',
+                            networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: 'eth_zilch',
+                                id: '0',
+                                jsonrpc: '0',
+                            }
+                        };
+
+                    });
+                }
+            }
+
+            class TestPusherClient implements IPusherClient {
+                subscribeToChannel(channelName: string, eventNames: [string], callback: (eventResponse: IEventResponse) => any): void {
+                    (channelName);
+                    (eventNames);
+                    callback({
+                        eventName: 'update_transaction',
+                        message: channelName
+                    });
+                }
+
+                unsubscribeFromChannel(channelName: string): void {
+                    (channelName);
+                }
+            }
+
+            const superblocksClient = new TestSuperblocksClient();
+            const pusherClient = new TestPusherClient();
+            const manualSignProvider = new ManualSignProvider(superblocksClient, pusherClient, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.send({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_sendTransaction',
+                    params: [],
+                });
+                return promise;
+            });
+        });
+
+        it('successfully sends message via RPC', async () => {
+            class TestRpcClient implements IRpcClient {
+                sendRpcJsonCall(endpoint: string, payload: JSONRPCRequestPayload): Promise<any> {
+                    return new Promise(async (resolve, _) => {
+                        (endpoint);
+                        (payload);
+                        return resolve([]);
+                    });
+                }
+            }
+
+            const rpcClient = new TestRpcClient();
+            const manualSignProvider = new ManualSignProvider(null, null, rpcClient);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            await assert.doesNotReject( async () => {
+                const promise = manualSignProvider.send({
+                    jsonrpc: 'eth_test',
+                    id: 0,
+                    method: 'eth_test',
+                    params: ['test'],
+                });
+                return promise;
+            });
+        });
+    });
+
+    describe('sendAsync:', () => {
+        it('successfully retrieve accounts', (done) => {
+            const manualSignProvider = new ManualSignProvider(null, null, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            manualSignProvider.sendAsync({
+                jsonrpc: 'eth_test',
+                id: 0,
+                method: 'eth_accounts',
+                params: [],
+            }, (err: Error | null, result?: JSONRPCResponsePayload) => {
+                assert.deepStrictEqual(null, err);
+                assert.notDeepStrictEqual(null, result);
+                done();
+            });
+        });
+
+        it('successfully sends message via Rest API', (done) => {
+            class TestSuperblocksClient implements ISuperblocksClient {
+                sendEthTransaction(transaction: ITransactionModel): Promise<ITransactionModel> {
+                    return new Promise(async (resolve, _) => {
+                        return resolve({
+                            projectId: transaction.projectId,
+                            buildConfigId: transaction.buildConfigId,
+                            from: transaction.from,
+                            networkId: transaction.networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: transaction.rpcPayload.method,
+                                id: transaction.rpcPayload.id,
+                                jsonrpc: transaction.rpcPayload.jsonrpc,
+                            }
+                        });
+                    });
+                }
+
+                createRelease(workspaceId: string, userToken: string, networkId: string): Promise<ITransactionModel> {
+                    return new Promise(async (_, __) => {
+                        (workspaceId);
+                        (userToken);
+                        return {
+                            projectId: 'id',
+                            buildConfigId: 'id',
+                            from: '0x0',
+                            networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: 'eth_zilch',
+                                id: '0',
+                                jsonrpc: '0',
+                            }
+                        };
+
+                    });
+                }
+            }
+
+            class TestPusherClient implements IPusherClient {
+                subscribeToChannel(channelName: string, eventNames: [string], callback: (eventResponse: IEventResponse) => any): void {
+                    (channelName);
+                    (eventNames);
+                    callback({
+                        eventName: 'update_transaction',
+                        message: channelName
+                    });
+                }
+
+                unsubscribeFromChannel(channelName: string): void {
+                    (channelName);
+                }
+            }
+
+            const superblocksClient = new TestSuperblocksClient();
+            const pusherClient = new TestPusherClient();
+            const manualSignProvider = new ManualSignProvider(superblocksClient, pusherClient, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            manualSignProvider.sendAsync({
+                jsonrpc: 'eth_test',
+                id: 0,
+                method: 'eth_sendTransaction',
+                params: [],
+            }, (err: Error | null, result?: JSONRPCResponsePayload) => {
+                assert.deepStrictEqual(null, err);
+                assert.notDeepStrictEqual(null, result);
+                done();
+            });
+        });
+
+        it('fails to send message via Rest API due to Superblocks Client failure', (done) => {
+            class TestSuperblocksClient implements ISuperblocksClient {
+                sendEthTransaction(transaction: ITransactionModel): Promise<ITransactionModel> {
+                    throw new Error('sendEthTransaction exception');
+                    return new Promise(async (resolve, _) => {
+                        return resolve({
+                            projectId: transaction.projectId,
+                            buildConfigId: transaction.buildConfigId,
+                            from: transaction.from,
+                            networkId: transaction.networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: transaction.rpcPayload.method,
+                                id: transaction.rpcPayload.id,
+                                jsonrpc: transaction.rpcPayload.jsonrpc,
+                            }
+                        });
+                    });
+                }
+
+                createRelease(workspaceId: string, userToken: string, networkId: string): Promise<ITransactionModel> {
+                    return new Promise(async (_, __) => {
+                        (workspaceId);
+                        (userToken);
+                        return {
+                            projectId: 'id',
+                            buildConfigId: 'id',
+                            from: '0x0',
+                            networkId,
+                            rpcPayload: {
+                                params: [],
+                                method: 'eth_zilch',
+                                id: '0',
+                                jsonrpc: '0',
+                            }
+                        };
+
+                    });
+                }
+            }
+
+            const superblocksClient = new TestSuperblocksClient();
+            const manualSignProvider = new ManualSignProvider(superblocksClient, null, null);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            manualSignProvider.sendAsync({
+                jsonrpc: 'eth_test',
+                id: 0,
+                method: 'eth_sendTransaction',
+                params: [],
+            }, (err: Error | null, result?: JSONRPCResponsePayload) => {
+                assert.deepStrictEqual('sendEthTransaction exception', err.toString());
+                assert.deepStrictEqual(null, result);
+                done();
+            });
+        });
+
+        it('successfully sends message via RPC', (done) => {
+            class TestRpcClient implements IRpcClient {
+                sendRpcJsonCall(endpoint: string, payload: JSONRPCRequestPayload): Promise<any> {
+                    return new Promise(async (resolve, _) => {
+                        (endpoint);
+                        (payload);
+                        return resolve([]);
+                    });
+                }
+            }
+
+            const rpcClient = new TestRpcClient();
+            const manualSignProvider = new ManualSignProvider(null, null, rpcClient);
+            const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
+            assert.doesNotThrow(() => {
+                manualSignProvider.init({
+                    from: fromAddress,
+                    endpoint: 'http://127.0.0.1',
+                    networkId: '1'
+                });
+            });
+
+            manualSignProvider.sendAsync({
+                jsonrpc: 'eth_test',
+                id: 0,
+                method: 'eth_test',
+                params: ['test'],
+            }, (err: Error | null, result?: JSONRPCResponsePayload) => {
+                assert.deepStrictEqual(null, err);
+                assert.notDeepStrictEqual(null, result);
+                done();
+            });
+        });
     });
 
     it('check all the possibilities to init the provider', () => {
@@ -52,114 +856,6 @@ describe('ManualSignProvider:', () => {
         assert.throws(() => { manualSignProvider.init({ from: '0x3117958590752b0871548Dd8715b4C4c41372d3d', endpoint: '', networkId: '' }); });
         assert.throws(() => { manualSignProvider.init({ from: '0x3117958590752b0871548Dd8715b4C4c41372d3d', endpoint: 'something', networkId: '' }); });
         assert.throws(() => { manualSignProvider.init({ from: '0x3117958590752b0871548Dd8715b4C4c41372d3d', endpoint: 'something', networkId: '1a' }); });
-        assert.doesNotThrow(() => { manualSignProvider.init({ from: '0x3117958590752b0871548Dd8715b4C4c41372d3d', endpoint: 'something', networkId: '1' }); });
-    });
-
-    it.skip('sends message targeting eth_accounts when accounts length is bigger than zero', () => {
-        // TODO
-    });
-
-    it.skip('sends message targeting eth_sendTransaction', () => {
-        // TODO
-    });
-
-    it.skip('sends message targeting eth_sendTransaction which resolves the Promise', () => {
-        // TODO
-    });
-
-    it.skip('sends message targeting eth_sign', () => {
-        // TODO
-    });
-
-    it.skip('sends message targeting eth_sign which resolves the Promise', () => {
-        // TODO
-    });
-
-    it.skip('sends synchronous message via provider interface', () => {
-        // TODO
-    });
-
-    it('fails to send synchronous message via provider interface due to invalid JSON response', async () => {
-        // const superblocksProvider = new ManualSignProvider({
-        //     from: '0x0101010100101010100101010100101010101010',
-        //     endpoint: 'https://superblocks.com/',
-        //     networkId: '0'
-        // });
-        // assert.notStrictEqual(superblocksProvider, undefined);
-        // assert.notStrictEqual(superblocksProvider, null);
-
-        // await assert.rejects( async () => {
-        //     const promise = superblocksProvider.send({
-        //         jsonrpc: 'eth_test',
-        //         id: 0,
-        //         method: 'eth_test',
-        //         params: ['test'],
-        //     });
-        //     return promise;
-        // }, {
-        //     message: 'invalid json response body at https://superblocks.com/ reason: Unexpected token < in JSON at position 0',
-        //     type: 'invalid-json'
-        // });
-    });
-
-    it.skip('sends asynchronous message via provider interface', () => {
-        // TODO
-    });
-
-    it('fails to send asynchronous message via provider interface due to invalid JSON response', () => {
-        // const superblocksProvider = new ManualSignProvider({
-        //     from: '0x0101010100101010100101010100101010101010',
-        //     endpoint: 'https://superblocks.com/',
-        //     networkId: '0'
-        // });
-        // assert.notStrictEqual(superblocksProvider, undefined);
-        // assert.notStrictEqual(superblocksProvider, null);
-
-        // superblocksProvider.sendAsync({
-        //     jsonrpc: 'eth_test',
-        //     id: 0,
-        //     method: 'eth_test',
-        //     params: ['test'],
-        // }, (error: any, result: any) => {
-        //     assert.deepStrictEqual(error.toString(), 'FetchError: invalid json response body at https://superblocks.com/ reason: Unexpected token < in JSON at position 0');
-        //     assert.deepStrictEqual(result, null);
-        //     done();
-        // });
-    });
-
-    it.skip('catches an error after sending asynchronous message via provider interface', () => {
-        // TODO
-    });
-
-    it.skip('retrieves accounts list', () => {
-        // TODO
-    });
-
-    it.skip('calls REST API', () => {
-        // TODO
-    });
-
-    it.skip('calls REST API and resolves the Promise', () => {
-        // TODO
-    });
-
-    it.skip('fails to call REST API', async () => {
-        // TODO
-    });
-
-    it.skip('sends message to remote endpoint which resolves the Promise', () => {
-        // TODO
-    });
-
-    it.skip('sends message to remote endpoint which rejects the Promise', () => {
-        // TODO
-    });
-
-    it.skip('successfully initializes the provider', () => {
-        // TODO
-    });
-
-    it.skip('fails to initialize the provider', () => {
-        // TODO
+        assert.doesNotThrow(() => { manualSignProvider.init({ from: '0x3117958590752b0871548Dd8715b4C4c41372d3d', endpoint: 'http://something', networkId: '1' }); });
     });
 });

--- a/src/pusher/pusher.client.spec.ts
+++ b/src/pusher/pusher.client.spec.ts
@@ -17,6 +17,7 @@
 import 'reflect-metadata';
 import * as assert from 'assert';
 import * as sinon from 'ts-sinon';
+import { SinonSandbox } from 'sinon';
 import { IPusherClient, IEventResponse } from '../ioc/interfaces';
 import { EventCallback } from 'pusher-js';
 import { PusherClient } from './pusher.client';
@@ -39,123 +40,97 @@ const mockPusher = <Pusher.Pusher> {
     }
 };
 
-describe('PusherClient: Test connectToPusher', () => {
-    it.skip('fails to create valid Pusher object due to bad identification key', () => {
-        // TODO
-    });
-
-    it.skip('fails to create valid Pusher object due to wrong cluster setting', () => {
-        // TODO
-    });
-});
-
-describe('PusherClient: Test subscribeToChannel', () => {
+describe('PusherClient:', () => {
+    let sandbox: SinonSandbox;
 
     beforeEach(() => {
-        pusherClient = new PusherClient(mockPusher);
+        // Remove console logs to make the test results cleaner
+        sandbox = sinon.default.createSandbox();
+        sandbox.stub(console, 'log');
     });
 
-    it.skip('checks subscribed channels data is empty at the start', () => {
-        // TODO
+    afterEach(() => {
+        sandbox.restore();
     });
 
-    it('subscribes to channel', (done) => {
-        assert.doesNotThrow(() => {
-            pusherClient.subscribeToChannel('test-channel', ['test_event'],
-                (eventResponse: IEventResponse) => {
-                    assert.deepStrictEqual(eventResponse.eventName, 'test_event');
-                    assert.deepStrictEqual(eventResponse.message, undefined);
-                    done();
+    describe('Test subscribeToChannel', () => {
+        beforeEach(() => {
+            pusherClient = new PusherClient(mockPusher);
+        });
+
+        it('subscribes to channel', (done) => {
+            assert.doesNotThrow(() => {
+                pusherClient.subscribeToChannel('test-channel', ['test_event'],
+                    (eventResponse: IEventResponse) => {
+                        assert.deepStrictEqual(eventResponse.eventName, 'test_event');
+                        assert.deepStrictEqual(eventResponse.message, undefined);
+                        done();
+                    }
+                );
+            });
+        });
+
+        it('checks subscriptions only map to specified entry in eventNames', (done) => {
+            // Keep track of calls to channel bind method
+            let bindCount = 0;
+            const modifiedMockChannel = <Pusher.Channel> {
+                bind(_eventName: string, callback: EventCallback, context?: any): any {
+                    bindCount++;
+                    callback(context, 'Some Data');
+                },
+            };
+
+            const modifiedMockPusher = <Pusher.Pusher> {
+                subscribe: (_channelName: string) => {
+                    return modifiedMockChannel;
                 }
-            );
+            };
+
+            pusherClient = new PusherClient(modifiedMockPusher);
+
+            let currentBindCount = 0;
+            assert.doesNotThrow(() => {
+                pusherClient.subscribeToChannel('test-channel', ['entry'],
+                    (eventResponse: IEventResponse) => {
+                        currentBindCount++;
+                        assert.notDeepStrictEqual(eventResponse, undefined);
+                        assert.deepStrictEqual(currentBindCount, bindCount);
+                        done();
+                    }
+                );
+            });
         });
     });
 
-    it.skip('successfully unsubscribes before overwriting existing channelName in subscribedChannels', () => {
-        // TODO
-    });
+    describe('Test unsubscribeFromChannel', () => {
+        beforeEach(() => {
+            pusherClient = new PusherClient(mockPusher);
+        });
 
-    it.skip('checks subscribedChannels changes after successful subscription', () => {
-        // TODO
-    });
+        it('successfully unsubscribes from previously subscribed channelName', (done) => {
+            assert.doesNotThrow( () => {
+                pusherClient.subscribeToChannel('test-channel', ['test_event'],
+                    (eventResponse: IEventResponse) => {
+                        assert.deepStrictEqual(eventResponse.eventName, 'test_event');
+                        assert.deepStrictEqual(eventResponse.message, undefined);
+                        done();
+                    }
+                );
+            });
 
-    it.skip('checks subscribedChannels remains unchanged after subscription failure', () => {
-        // TODO
-    });
+            const spy = sinon.default.spy(mockChannel, 'unbind');
+            sinon.default.assert.calledOnce(spy);
 
-    it('checks subscriptions only map to specified entry in eventNames', (done) => {
-        // Keep track of calls to channel bind method
-        let bindCount = 0;
-        const modifiedMockChannel = <Pusher.Channel> {
-            bind(_eventName: string, callback: EventCallback, context?: any): any {
-                bindCount++;
-                callback(context, 'Some Data');
-            },
-        };
+            assert.doesNotThrow( () => {
+                pusherClient.unsubscribeFromChannel('test-channel');
+            });
+        });
 
-        const modifiedMockPusher = <Pusher.Pusher> {
-            subscribe: (_channelName: string) => {
-                return modifiedMockChannel;
-            }
-        };
-
-        pusherClient = new PusherClient(modifiedMockPusher);
-
-        let currentBindCount = 0;
-        assert.doesNotThrow(() => {
-            pusherClient.subscribeToChannel('test-channel', ['entry'],
-                (eventResponse: IEventResponse) => {
-                    currentBindCount++;
-                    console.log(currentBindCount);
-                    console.log(bindCount);
-                    assert.notDeepStrictEqual(eventResponse, undefined);
-                    assert.deepStrictEqual(currentBindCount, bindCount);
-                    done();
-                }
-            );
+        it('tries to unsubscribe from unknown channelName', () => {
+            assert.doesNotThrow( () => {
+                pusherClient.unsubscribeFromChannel('test-channel-unknown');
+            });
         });
     });
 
-    it.skip('checks subscriptions do not link to unspecified eventNames', () => {
-        // TODO
-    });
-
-    it.skip('fails to subscribe to channel without binding to any event', () => {
-        // TODO
-    });
-});
-
-describe('PusherClient: Test unsubscribeFromChannel', () => {
-    beforeEach(() => {
-        pusherClient = new PusherClient(mockPusher);
-    });
-
-    it('successfully unsubscribes from previously subscribed channelName', (done) => {
-        assert.doesNotThrow( () => {
-            pusherClient.subscribeToChannel('test-channel', ['test_event'],
-                (eventResponse: IEventResponse) => {
-                    assert.deepStrictEqual(eventResponse.eventName, 'test_event');
-                    assert.deepStrictEqual(eventResponse.message, undefined);
-                    done();
-                }
-            );
-        });
-
-        const spy = sinon.default.spy(mockChannel, 'unbind');
-        sinon.default.assert.calledOnce(spy);
-
-        assert.doesNotThrow( () => {
-            pusherClient.unsubscribeFromChannel('test-channel');
-        });
-    });
-
-    it.skip('checks subscribedChannels gets empty after un subscription', () => {
-        // TODO
-    });
-
-    it('tries to unsubscribe from unknown channelName', () => {
-        assert.doesNotThrow( () => {
-            pusherClient.unsubscribeFromChannel('test-channel');
-        });
-    });
 });

--- a/src/rpc/rpc.client.spec.ts
+++ b/src/rpc/rpc.client.spec.ts
@@ -1,0 +1,85 @@
+// Copyright 2019 Superblocks AB
+//
+// This file is part of Superblocks.
+//
+// Superblocks is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation version 3 of the License.
+//
+// Superblocks is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Superblocks.  If not, see <http://www.gnu.org/licenses/>.
+
+import 'reflect-metadata';
+import * as assert from 'assert';
+import fetchMock, { MockResponse } from 'fetch-mock';
+import * as sinon from 'ts-sinon';
+import { SinonSandbox } from 'sinon';
+import { IRpcClient } from '../ioc/interfaces';
+import { RpcClient } from './rpc.client';
+
+describe('RpcClient:', () => {
+
+    let sandbox: SinonSandbox;
+
+    beforeEach(() => {
+        // Remove console logs to make the test results cleaner
+        sandbox = sinon.default.createSandbox();
+        sandbox.stub(console, 'log');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('sendRpcJsonCall:', () => {
+        let rpcClient: IRpcClient;
+
+        it('sends JSON-RPC request', () => {
+            const endpoint = 'https://some-url/transactions';
+            const mockFetch = fetchMock.sandbox().post(endpoint, <MockResponse>{ status: 201, body: { result: 1 } });
+
+            rpcClient = new RpcClient(mockFetch);
+
+            assert.doesNotThrow(async () => {
+                const response = await rpcClient.sendRpcJsonCall(endpoint, {
+                    params: [],
+                    method: 'eth_unknown',
+                    id: 0,
+                    jsonrpc: '2.0'
+                });
+                console.log(response);
+                assert.deepStrictEqual(1, response);
+            });
+        });
+
+        it('fails to send JSON-RPC request due to failure error', async () => {
+            const endpoint = 'https://some-url/transactions';
+            const mockFetch = fetchMock.sandbox().post(endpoint, <MockResponse>{
+                throws: new Error('Error during fetch'),
+                status: 400,
+                body: {
+                    message: 'This is an error'
+                }
+            });
+
+            rpcClient = new RpcClient(mockFetch);
+
+            assert.rejects(async () => {
+                const response = await rpcClient.sendRpcJsonCall(endpoint, {
+                    params: [],
+                    method: 'eth_unknown',
+                    id: 0,
+                    jsonrpc: '2.0'
+                });
+            }, {
+                name: 'Error',
+                message: 'Error during fetch'
+            });
+        });
+    });
+});


### PR DESCRIPTION
**[superblocks.provider]**

+ Add console log stub

+ Add a set of valid protocol tests around `isValidEndpoint`
+ Add a set of error checks against `isValidEndpoint`

+ Add test covering successful `init`
+ Add a set of tests covering possible `init` failures

+ Add test retrieving accounts successfully
+ Add test failing to retrieve accounts due to initialized provider

+ Add tests to cover `eth_accounts` via `sendMessage`
+ Add tests covering _API_ calls via `sendMessage`
+ Add tests covering _RPC_ calls via `sendMessage`

+ Add test to verify _eth_accounts_ via plain `send`
+ Add test to verify _API_ calls via `send`
+ Add test to verify _RPC_ calls via `send`

+ Add test to check _eth_accounts_ via direct `sendAsync` call
+ Add couple of tests checking _API_ calls via `sendAsync`
+ Add test to check _RPC_ calls via `sendAsync`

- Remove pending tests as they are now covered by this patch

- Remove commented out tests as they are covered by the additions

**[pusher.client]**
+ Add `console` `log` stub

* Organize tests in different `describe` blocks

- Remove other tests marked as pending as they are either not possible to test or they are now covered by this patch


**[rpc.client]**

+ Add test verifying successful _JSON-RPC_ request

+ Add test to check _JSON-RPC_ endpoint request failure


**[superblocks.client]**

+ Add `createRelease` test block

+ Add test to verify successful release creation

+ Add test to check release creation failure case

* Separate each set of tests in its own `describe` block

* Move `stub` code up a level

* Move `mockUtils` initialization up a level

* Rename error tests to clarify _API_ is accessible with an error