### PR TITLE
Map known networkIds to network names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-web3-provider",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Web3 provider to create a secure channel between our CI runners and the Superblocks platform to handle Smart Contract deployments through our blockchain dedicated DevOps platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/ioc/interfaces.ts
+++ b/src/ioc/interfaces.ts
@@ -8,6 +8,7 @@ export type Pusher = typeof pusher.prototype;
 
 export interface ISuperblocksUtils {
     getApiBaseUrl: () => string;
+    networkIdToName: (networkId: string) => string;
 }
 
 export interface ISuperblocksClient {

--- a/src/providers/super.provider.spec.ts
+++ b/src/providers/super.provider.spec.ts
@@ -20,7 +20,7 @@ import * as sinon from 'ts-sinon';
 import { SinonSandbox } from 'sinon';
 import { ManualSignProvider } from './super.provider';
 import { ISuperblocksClient, IPusherClient, IRpcClient, IEventResponse, IManualSignProvider } from '../ioc/interfaces';
-import { ITransactionModel, IDeploymentModel } from '../superblocks/models';
+import { ITransactionModel, IDeploymentModel, ITransactionParamsModel } from '../superblocks/models';
 import { JSONRPCRequestPayload, JSONRPCResponsePayload } from 'ethereum-protocol';
 
 
@@ -30,7 +30,7 @@ import { JSONRPCRequestPayload, JSONRPCResponsePayload } from 'ethereum-protocol
 
 
 class TestSuperblocksClient implements ISuperblocksClient {
-    sendEthTransaction(deploymentId: string, _token: string, transaction: ITransactionModel): Promise<ITransactionModel> {
+    sendEthTransaction(deploymentId: string, _token: string, transaction: ITransactionParamsModel): Promise<ITransactionModel> {
         return Promise.resolve({
                 id: '1234',
                 deploymentId,
@@ -388,7 +388,7 @@ describe('ManualSignProvider:', () => {
 
         it('fails to send message via Rest API due to Superblocks Client failure', async () => {
             class MockSuperblocksClient implements ISuperblocksClient {
-                sendEthTransaction(_deploymentId: string, _token: string, _transaction: ITransactionModel): Promise<ITransactionModel> {
+                sendEthTransaction(_deploymentId: string, _token: string, _transaction: ITransactionParamsModel): Promise<ITransactionModel> {
                     throw new Error('sendEthTransaction exception');
                 }
 
@@ -587,7 +587,7 @@ describe('ManualSignProvider:', () => {
 
         it('fails to send message via Rest API due to Superblocks Client failure', async () => {
             class MockSuperblocksClient implements ISuperblocksClient {
-                sendEthTransaction(_deploymentId: string, _token: string, _transaction: ITransactionModel): Promise<ITransactionModel> {
+                sendEthTransaction(_deploymentId: string, _token: string, _transaction: ITransactionParamsModel): Promise<ITransactionModel> {
                     throw new Error('sendEthTransaction exception');
                 }
 

--- a/src/providers/super.provider.spec.ts
+++ b/src/providers/super.provider.spec.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert';
 import * as sinon from 'ts-sinon';
 import { SinonSandbox } from 'sinon';
 import { ManualSignProvider } from './super.provider';
-import { ISuperblocksClient, IPusherClient, IRpcClient, IEventResponse, IManualSignProvider } from '../ioc/interfaces';
+import { ISuperblocksClient, IPusherClient, IRpcClient, IEventResponse, IManualSignProvider, ISuperblocksUtils } from '../ioc/interfaces';
 import { ITransactionModel, IDeploymentModel, ITransactionParamsModel } from '../superblocks/models';
 import { JSONRPCRequestPayload, JSONRPCResponsePayload } from 'ethereum-protocol';
 
@@ -27,7 +27,6 @@ import { JSONRPCRequestPayload, JSONRPCResponsePayload } from 'ethereum-protocol
 // Disable specific tslint warnings
 /* tslint:disable:no-unused-expression */
 /* tslint:disable:max-classes-per-file */
-
 
 class TestSuperblocksClient implements ISuperblocksClient {
     sendEthTransaction(deploymentId: string, _token: string, transaction: ITransactionParamsModel): Promise<ITransactionModel> {
@@ -73,6 +72,15 @@ class TestPusherClient implements IPusherClient {
     }
 }
 
+class TestSuperblocksUtils implements ISuperblocksUtils {
+    getApiBaseUrl() {
+        return 'http://someBaseUrl.com/'
+    }
+    networkIdToName(_networkId: string) {
+        return 'someName';
+    }
+}
+
 class TestRpcClient implements IRpcClient {
     sendRpcJsonCall(endpoint: string, payload: JSONRPCRequestPayload): Promise<any> {
         return new Promise(async (resolve, _) => {
@@ -90,7 +98,7 @@ describe('ManualSignProvider:', () => {
     beforeEach(() => {
         // Remove console logs to make the test results cleaner
         sandbox = sinon.default.createSandbox();
-        // sandbox.stub(console, 'log');
+        sandbox.stub(console, 'log');
     });
 
     afterEach(() => {
@@ -146,7 +154,8 @@ describe('ManualSignProvider:', () => {
 
         beforeEach(() => {
             const client = new TestSuperblocksClient();
-            manualSignProvider = new ManualSignProvider(client, null, null);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(client, null, null, mockUtils);
         });
 
         it('initializes manual sign provider successfully', () => {
@@ -261,7 +270,8 @@ describe('ManualSignProvider:', () => {
 
         beforeEach(() => {
             const client = new TestSuperblocksClient();
-            manualSignProvider = new ManualSignProvider(client, null, null);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(client, null, null, mockUtils);
         });
 
         it('retrieves accounts successfully', async () => {
@@ -295,7 +305,8 @@ describe('ManualSignProvider:', () => {
             const client = new TestSuperblocksClient();
             pusherClient = new TestPusherClient();
             const rpcClient = new TestRpcClient();
-            manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient, mockUtils);
         });
 
         it('successfully retrieve accounts', async () => {
@@ -405,7 +416,8 @@ describe('ManualSignProvider:', () => {
             }
 
             const superblocksClient = new MockSuperblocksClient();
-            manualSignProvider = new ManualSignProvider(superblocksClient, null, null);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(superblocksClient, null, null, mockUtils);
             const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
 
             await manualSignProvider.init({
@@ -471,7 +483,8 @@ describe('ManualSignProvider:', () => {
             const client = new TestSuperblocksClient();
             const pusherClient = new TestPusherClient();
             const rpcClient = new TestRpcClient();
-            manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient, mockUtils);
         });
 
         it('successfully retrieve accounts', async () => {
@@ -539,7 +552,8 @@ describe('ManualSignProvider:', () => {
             const client = new TestSuperblocksClient();
             const pusherClient = new TestPusherClient();
             const rpcClient = new TestRpcClient();
-            manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient, mockUtils);
         });
 
         it('successfully retrieve accounts', async () => {
@@ -604,7 +618,8 @@ describe('ManualSignProvider:', () => {
             }
 
             const superblocksClient = new MockSuperblocksClient();
-            manualSignProvider = new ManualSignProvider(superblocksClient, null, null);
+            const mockUtils = new TestSuperblocksUtils();
+            manualSignProvider = new ManualSignProvider(superblocksClient, null, null, mockUtils);
             const fromAddress = '0x3117958590752b0871548Dd8715b4C4c41372d3d';
 
             await manualSignProvider.init({
@@ -652,7 +667,8 @@ describe('ManualSignProvider:', () => {
         const client = new TestSuperblocksClient();
         const pusherClient = new TestPusherClient();
         const rpcClient = new TestRpcClient();
-        const manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient);
+        const mockUtils = new TestSuperblocksUtils();
+        const manualSignProvider = new ManualSignProvider(client, pusherClient, rpcClient, mockUtils);
 
         assert.rejects(() => manualSignProvider.init({ deploymentSpaceId: '', token: '', from: '', endpoint: '', networkId: '' }));
         assert.rejects(() => manualSignProvider.init({ deploymentSpaceId: 'dummy', token: '', from: '', endpoint: '', networkId: '' }));

--- a/src/providers/super.provider.ts
+++ b/src/providers/super.provider.ts
@@ -21,7 +21,7 @@ import Url from 'url';
 import { JSONRPCRequestPayload, JSONRPCErrorCallback } from 'ethereum-protocol';
 import { ITransactionModel } from '../superblocks/models';
 import { TYPES } from '../ioc/types';
-import { ISuperblocksClient, IManualSignProvider, IPusherClient, IRpcClient, JSONRpcCallback, IManualSignProviderOptions } from '../ioc/interfaces';
+import { ISuperblocksClient, IManualSignProvider, IPusherClient, IRpcClient, JSONRpcCallback, IManualSignProviderOptions, ISuperblocksUtils } from '../ioc/interfaces';
 
 @injectable()
 export class ManualSignProvider implements IManualSignProvider {
@@ -31,6 +31,7 @@ export class ManualSignProvider implements IManualSignProvider {
     private superblocksClient: ISuperblocksClient;
     private pusherClient: IPusherClient;
     private rpcClient: IRpcClient;
+    private superblocksUtils: ISuperblocksUtils;
     private options: IManualSignProviderOptions;
     private deploymentId: string;
     private pendingTxs: Map<string, ITransactionModel>;
@@ -38,11 +39,13 @@ export class ManualSignProvider implements IManualSignProvider {
     constructor(
         @inject(TYPES.SuperblocksClient) superblocksClient: ISuperblocksClient,
         @inject(TYPES.PusherClient) pusherClient: IPusherClient,
-        @inject(TYPES.RpcClient) rpcClient: IRpcClient
+        @inject(TYPES.RpcClient) rpcClient: IRpcClient,
+        @inject(TYPES.SuperblocksUtils) superblocksUtils: ISuperblocksUtils,
     ) {
         this.superblocksClient = superblocksClient;
         this.pusherClient = pusherClient;
         this.rpcClient = rpcClient;
+        this.superblocksUtils = superblocksUtils;
     }
 
     public static isValidEndpoint(endpoint: string): boolean {
@@ -79,7 +82,7 @@ export class ManualSignProvider implements IManualSignProvider {
         this.pendingTxs = new Map();
 
         // Let make sure we crete a new deployment on every init in order to group txs together
-        const deployment = await this.superblocksClient.createDeployment(options.deploymentSpaceId, options.token, options.networkId);
+        const deployment = await this.superblocksClient.createDeployment(options.deploymentSpaceId, options.token, this.superblocksUtils.networkIdToName(options.networkId));
         this.deploymentId = deployment.id;
     }
 
@@ -124,6 +127,7 @@ export class ManualSignProvider implements IManualSignProvider {
             try {
                 transaction = await this.superblocksClient.sendEthTransaction(this.deploymentId, this.options.token, {
                     networkId,
+                    endpoint: this.options.endpoint,
                     from: this.options.from,
                     rpcPayload: payload
                 });

--- a/src/superblocks/models/transaction-params.model.ts
+++ b/src/superblocks/models/transaction-params.model.ts
@@ -19,6 +19,7 @@ import { JSONRPCRequestPayload } from 'ethereum-protocol';
 export interface ITransactionParamsModel {
     from: string;
     networkId: string;
+    endpoint: string;
     rpcPayload: JSONRPCRequestPayload;
     ciJobId?: string;
 }

--- a/src/superblocks/superblocks.client.ts
+++ b/src/superblocks/superblocks.client.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Superblocks.  If not, see <http://www.gnu.org/licenses/>.
 // import fetch from 'node-fetch';
-import { ITransactionModel, IDeploymentModel } from './models';
+import { ITransactionModel, IDeploymentModel, ITransactionParamsModel } from './models';
 import { injectable, inject } from 'inversify';
 import { TYPES } from '../ioc/types';
 import { Fetch, ISuperblocksUtils, ISuperblocksClient } from '../ioc/interfaces';
@@ -32,7 +32,7 @@ export class SuperblocksClient implements ISuperblocksClient {
         this.utils = utils;
     }
 
-    async sendEthTransaction(deploymentId: string, token: string, transaction: ITransactionModel): Promise<ITransactionModel> {
+    async sendEthTransaction(deploymentId: string, token: string, transaction: ITransactionParamsModel): Promise<ITransactionModel> {
         const response = await this.fetch(`${this.utils.getApiBaseUrl()}/deployments/${deploymentId}/transactions`, {
             method: 'POST',
             headers: {
@@ -53,25 +53,30 @@ export class SuperblocksClient implements ISuperblocksClient {
     }
 
     async createDeployment(deploymentSpaceId: string, token: string, environment: string): Promise<IDeploymentModel> {
-        const response = await this.fetch(`${this.utils.getApiBaseUrl()}/deployment-spaces/${deploymentSpaceId}/deployments/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'project-token': token
-            },
-            body: JSON.stringify({
-                environment,
-                type: 'ethereum'
-            })
-        });
 
-        if (response.ok) {
-            const deployment = await response.json();
-            console.log('[Superblocks client] deployment created', deployment);
-            return deployment;
-        } else {
-            const error = await response.text();
-            throw new Error(`[Superblocks client] cannot create a deployment: ${error}`);
+        try {
+            const response = await this.fetch(`${this.utils.getApiBaseUrl()}/deployment-spaces/${deploymentSpaceId}/deployments/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'project-token': token
+                },
+                body: JSON.stringify({
+                    environment,
+                    type: 'ethereum'
+                })
+            });
+
+            if (response.ok) {
+                const deployment = await response.json();
+                console.log('[Superblocks client] deployment created', deployment);
+                return deployment;
+            } else {
+                const error = await response.text();
+                throw new Error(`[Superblocks client] cannot create a deployment: ${error}`);
+            }
+        } catch (e) {
+            console.log(e);
         }
     }
 }

--- a/src/superblocks/utils.ts
+++ b/src/superblocks/utils.ts
@@ -19,7 +19,7 @@ import { ISuperblocksUtils } from '../ioc/interfaces';
 
 @injectable()
 export class SuperblocksUtils implements ISuperblocksUtils {
-    getApiBaseUrl() {
+    getApiBaseUrl(): string {
         if (process.env.LOCAL) {
             return 'http://localhost:2999/v1';
         } else if (process.env.DEVELOP) {
@@ -27,6 +27,23 @@ export class SuperblocksUtils implements ISuperblocksUtils {
         } else {
             return `https://api.superblocks.com/v1`;
         }
+    }
+
+    networkIdToName(networkId: string): string {
+        switch (networkId) {
+            case '1':
+                return 'Mainnet';
+            case '3':
+                return 'Ropsten';
+            case '4':
+                return 'Rinkeby';
+            case '5':
+                return 'Görli';
+            case '42':
+                return 'Kovan';
+            default:
+                return networkId;
+    }
     }
 }
 


### PR DESCRIPTION
- When creating a release, we need to provide an environment name to it. In order to make it more descriptive, let's match the networkId to a given name so when displaying in Superblocks dashboard is more readable. 